### PR TITLE
Align voter model infrastructure with shared Ising workflow

### DIFF
--- a/src/lrgsglib/Ccore/statsys/voterM/LRGSG_vm.c
+++ b/src/lrgsglib/Ccore/statsys/voterM/LRGSG_vm.c
@@ -8,10 +8,15 @@
  * 
  * @return
  */
-void voter_model_1step(size_t nd, spin_tp s, size_tp nlen, size_tp *neighs, double_p *edgl) {
-    size_t sel_neigh_n = (size_t) (RNG_u64() % *(nlen + nd));
-    size_t sel_neigh = *(*(neighs + nd) + sel_neigh_n);
-    *(s + nd) = *(*(edgl + nd) + sel_neigh_n) * *(s + sel_neigh);
+void voter_model_1step(size_t nd, spin_tp s, size_tp nlen, NodesEdges node_edges) {
+    size_t degree = *(nlen + nd);
+    if (!degree)
+        return;
+    size_t sel = (size_t)(RNG_u64() % degree);
+    size_t neighbour = node_edges[nd].neighbors[sel];
+    double weight = node_edges[nd].weights[sel];
+    int sign = (weight < 0.0) ? -1 : 1;
+    *(s + nd) = (int8_t)(sign * *(s + neighbour));
 }
 
 /** 
@@ -21,7 +26,7 @@ void voter_model_1step(size_t nd, spin_tp s, size_tp nlen, size_tp *neighs, doub
  * 
  * @return
  */
-void voter_model_Nstep(size_t N, spin_tp s, size_tp nlen, size_tp *neighs, double_p *edgl) {
-    for (size_t i = 0; i < N; i++) 
-        voter_model_1step((size_t) (RNG_u64() % N), s, nlen, neighs, edgl);
+void voter_model_Nstep(size_t N, spin_tp s, size_tp nlen, NodesEdges node_edges) {
+    for (size_t i = 0; i < N; i++)
+        voter_model_1step((size_t)(RNG_u64() % N), s, nlen, node_edges);
 }

--- a/src/lrgsglib/Ccore/statsys/voterM/LRGSG_vm.h
+++ b/src/lrgsglib/Ccore/statsys/voterM/LRGSG_vm.h
@@ -6,8 +6,8 @@
 #ifndef __LRGSGVMLIB_H_INC__
 #define __LRGSGVMLIB_H_INC__
 
-void voter_model_1step(size_t nd, spin_tp s, size_tp nlen, size_tp *neighs, double_p *edgl);
-void voter_model_Nstep(size_t N, spin_tp s, size_tp nlen, size_tp *neighs, double_p *edgl);
+void voter_model_1step(size_t nd, spin_tp s, size_tp nlen, NodesEdges node_edges);
+void voter_model_Nstep(size_t N, spin_tp s, size_tp nlen, NodesEdges node_edges);
 
 
 #endif /* __LRGSGVMLIB_H_INC__ */

--- a/src/lrgsglib/Ccore/statsys/voterM/voter_model.c
+++ b/src/lrgsglib/Ccore/statsys/voterM/voter_model.c
@@ -1,190 +1,73 @@
-#include "LRGSG_customs.h"
 #include "LRGSG_vm.h"
 #include "LRGSG_utils.h"
 #include "sfmtrng.h"
 
-#define MOD_SAVE 1
+#define EXPECTED_ARGC (7 + 1)
 
-#define T_EQ_STEP (eqSTEP * N)
-
-#define VTR_DIR "%svoter/"
-#define SINI_FNAME VTR_DIR "N=%zu/s_%s" BINX
-#define FOUT_FNAME VTR_DIR "N=%zu/out_%s_%s" BINX
-#define CLID_FNAME VTR_DIR "N=%zu/cl%zu_%s" BINX
-#define CLOUT_FNAME VTR_DIR "N=%zu/outcl%zu_%s_T=%.3g_%s%s"
-#define ENE_FNAME VTR_DIR "N=%zu/ene_%s_T=%.3g_%s" BINX
-
-#define GRPH_DIR "%sgraphs/"
-#define ADJ_FNAME GRPH_DIR "N=%zu/adj_%s" BINX
-#define EDGL_FNAME GRPH_DIR "N=%zu/edgel_%s" TXTX
-
-sfmt_t sfmt;
-uint32_t *seed_rand;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-
-
+#define PSTR "p=%.3g"
+#define VTR_DIR "%s/voter/%s/"
+#define SINI_FNAME VTR_DIR "s_" PSTR "%s" BINX
+#define MAGN_FNAME VTR_DIR "m_" PSTR "%s" BINX
+#define GRPH_DIR "%s/graph/%s/"
+#define EDGL_FNAME GRPH_DIR "edgelist_" PSTR "%s" BINX
 
 int main(int argc, char *argv[]) {
-    /* seed the SFMT RNG */
+    if (argc < EXPECTED_ARGC) {
+        fprintf(stderr, "Usage: %s N p eqSTEP datdir syshape run_id out_id\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
     __set_seed_SFMT();
-    /* variables */
-    FILE *f_sini, *f_adj, *f_edgel, *f_ene;
-    FILE **f_cl, **f_out, *f_out0;
-    const char *mod_save, *ext_save;
-    char *ptr, *datdir, *code_id, *out_id, buf[STRL512];
-    double T, p;
-    double *ene, *magn;
-    spin_tp s;
-    size_t N, side, Noclust, tmp, eqSTEP;
-    size_tp neigh_len, cl_l;
-    size_tp *neighs, *cl_i;
-    double_p *mclus, *adj, *edgl;
-    /* unused variables */
-    UNUSED(p);
-    UNUSED(argc);
-    UNUSED(side);
-    /* init variables */
-    N = strtozu(argv[1]);
-    side = (size_t)sqrt(N);
-    p = strtod(argv[2], &ptr);
-    // Noclust = strtozu(argv[4]);
-    eqSTEP = strtozu(argv[3]);
-    datdir = argv[4];
-    code_id = argv[5];
-    out_id = argv[6];
-    /* open adjacency matrix file */
-    sprintf(buf, ADJ_FNAME, datdir, N, code_id);
-    __fopen(&f_adj, buf, "rb");
-    /* open magnetization initial condition  */
-    sprintf(buf, SINI_FNAME, datdir, N, code_id);
+
+    char *ptr;
+    size_t N = strtozu(argv[1]);
+    double p = strtod(argv[2], &ptr);
+    size_t eqSTEP = strtozu(argv[3]);
+    const char *datdir = argv[4];
+    const char *syshape = argv[5];
+    const char *run_id = argv[6];
+    const char *out_id = argv[7];
+
+    char buf[STRL512];
+    FILE *f_sini;
+    sprintf(buf, SINI_FNAME, datdir, syshape, p, run_id);
     __fopen(&f_sini, buf, "rb");
-
-    sprintf(buf, FOUT_FNAME, datdir, N, code_id, out_id);
-    __fopen(&f_out0, buf, "wb");
-
-    /* open cluster indices files */
-    // f_cl = __chMalloc(sizeof(*f_cl) * Noclust);
-    // for (size_t i = 0; i < Noclust; i++) {
-    //     sprintf(buf, CLID_FNAME, datdir, N, i, code_id);
-    //     __fopen((f_cl + i), buf, "rb");
-    // }
-    /* open out files */
-    // switch (MOD_SAVE) {
-    //     case 0: {
-    //         mod_save = "ab";
-    //         ext_save = BINX;
-    //         break;
-    //     }
-    //     case 1: {
-    //         mod_save = "a+";
-    //         ext_save = TXTX;
-    //         break;
-    //     }
-    // }
-    // f_out = malloc(sizeof(*f_out) * Noclust);
-    // for (size_t i = 0; i < Noclust; i++) {
-    //     sprintf(buf, CLOUT_FNAME, datdir, N, i, code_id, T, out_id, ext_save);
-    //     __fopen((f_out + i), buf, mod_save);
-    // }
-    /* fill adjacency matrix */
-    adj = __chMalloc(N * sizeof(*adj));
-    for (size_t i = 0; i < N; i++)
-        *(adj + i) = __chMalloc(N * sizeof(**adj));
-    __fill_adj__(&f_adj, N, &adj);
-    /* fill initial condition */
-    s = __chMalloc(N * sizeof(*s));
+    spin_tp s = __chMalloc(N * sizeof(*s));
     __fread_check(fread(s, sizeof(*s), N, f_sini), N);
-    /* fill clusters indices */
-    // cl_l = __chCalloc(Noclust, sizeof(*cl_l));
-    // cl_i = __chMalloc(Noclust * sizeof(*cl_i));
-    // for (size_t i = 0; i < Noclust; i++) {
-    //     cl_i[i] = __chMalloc((cl_l[i] + 1) * sizeof(**cl_i));
-    //     while (fread(&cl_i[i][cl_l[i]++], sizeof(*cl_i[i]), 1, f_cl[i]) == 1)
-    //         cl_i[i] = realloc(cl_i[i], (cl_l[i] + 1) * sizeof(*cl_i[i]));
-    //     cl_l[i]--;
-    // }
-    /* fill edge list, neighbours list and neighbours lengths */
-    edgl = __chMalloc(N * sizeof(*edgl));
-    neighs = __chMalloc(N * sizeof(*neighs));
-    neigh_len = __chMalloc(N * sizeof(*neigh_len));
-    sprintf(buf, EDGL_FNAME, datdir, N, code_id);
-    if (__feexist(buf)) {
-        __fopen(&f_edgel, buf, "r+");
-        __fill_edgl_read__(&f_edgel, N, &edgl, &neighs, &neigh_len);
-    } else {
-        __fopen(&f_edgel, buf, "w+");
-        __fill_edgl_make__(&f_edgel, N, &adj, &edgl, &neighs, &neigh_len);
-    }
-    /* allocate energy array and mclust */
-    // ene = __chMalloc(sizeof(*ene) * (T_EQ_STEP + T_THERM_STEP));
-    // mclus = __chMalloc(sizeof(*mclus) * Noclust);
-    // for (size_t i = 0; i < Noclust; i++)
-    //     mclus[i] = __chMalloc(sizeof(**mclus) * T_EQ_STEP);
-    magn = __chMalloc(T_EQ_STEP * sizeof(*magn));
-    for (size_t t = 0; t < T_EQ_STEP; t++) {
-        voter_model_Nstep(N, s, neigh_len, neighs, edgl);
-        magn[t] = calc_magn(N, s);
-        // fwrite(s, sizeof(*s), N, f_out0);
-    }
-    fwrite(magn, sizeof(*magn), T_EQ_STEP, f_out0);
-    // switch (MOD_SAVE) {
-    // case 0:
-    //     sprintf(buf, ENE_FNAME, datdir, N, code_id, T, out_id);
-    //     __fopen(&f_ene, buf, "ab");
-    //     for (size_t i = 0; i < Noclust; i++)
-    //         fwrite(mclus[i], sizeof(**mclus), T_EQ_STEP, f_out[i]);
-    //     fwrite(ene, sizeof(*ene), (T_EQ_STEP + T_THERM_STEP), f_ene);
-    //     fclose(f_ene);
-    //     break;
-    // case 1:
-    //     for (size_t i = 0; i < Noclust; i++)
-    //         fprintf(*(f_out + i), "%g %g\n",
-    //                 sum_vs(T_EQ_STEP, *(mclus + i)) / T_EQ_STEP,
-    //                 sum_vs_2(T_EQ_STEP, *(mclus + i)) / T_EQ_STEP);
-    //     break;
-    // }
-    /* closing files and freeing arrays*/
-    free(magn);
-    fclose(f_out0);
-    fclose(f_adj);
     fclose(f_sini);
-    // tmp = Noclust;
-    // while (tmp)
-    //     fclose(f_cl[--tmp]);
-    // free(f_cl);
-    // tmp = Noclust;
-    // while (tmp)
-    //     fclose(f_out[--tmp]);
-    // free(f_out);
-    tmp = N;
-    while (tmp)
-        free(adj[--tmp]);
-    free(adj);
-    free(s);
-    // tmp = Noclust;
-    // while (tmp)
-    //     free(cl_i[--tmp]);
-    // free(cl_i);
-    // free(cl_l);
-    fclose(f_edgel);
-    tmp = N;
-    while (tmp)
-        free(edgl[--tmp]);
-    free(edgl);
-    free(neigh_len);
-    tmp = N;
-    while (tmp)
-        free(neighs[--tmp]);
-    free(neighs);
-    
-    // free(ene);
-    // tmp = Noclust;
-    // while (tmp)
-    //     free(mclus[--tmp]);
-    // free(mclus);
-}
-// Your code here
 
-#pragma GCC diagnostic pop
+    Edges edges;
+    NodesEdges node_edges;
+    size_tp neigh_len;
+    sprintf(buf, EDGL_FNAME, datdir, syshape, p, run_id);
+    process_edges(buf, N, &edges, &node_edges, &neigh_len);
+
+    FILE *f_magn;
+    sprintf(buf, MAGN_FNAME, datdir, syshape, p, out_id);
+    __fopen(&f_magn, buf, "wb");
+
+    double *magn = __chMalloc(eqSTEP * sizeof(*magn));
+    for (size_t t = 0; t < eqSTEP; ++t) {
+        voter_model_Nstep(N, s, neigh_len, node_edges);
+        magn[t] = calc_magn(N, s);
+    }
+    fwrite(magn, sizeof(*magn), eqSTEP, f_magn);
+    fclose(f_magn);
+
+    fwrite(s, sizeof(*s), N, stdout);
+    fflush(stdout);
+
+    free(magn);
+    free(edges);
+    for (size_t i = 0; i < N; ++i) {
+        if (neigh_len[i]) {
+            free(node_edges[i].neighbors);
+            free(node_edges[i].weights);
+        }
+    }
+    free(node_edges);
+    free(neigh_len);
+    free(s);
+
+    return EXIT_SUCCESS;
+}

--- a/src/lrgsglib/nx_patches/SignedGraph/SignedGraph.py
+++ b/src/lrgsglib/nx_patches/SignedGraph/SignedGraph.py
@@ -785,7 +785,8 @@ class SignedGraph:
     #
     from ._exports import __export_graph__
     from ._exports import _export_edgel_bin
-    from ._exports import _export_eigV 
+    from ._exports import export_adj_bin
+    from ._exports import _export_eigV
     from ._exports import export_eigV_all
     from ._exports import export_ising_clust
     #
@@ -882,6 +883,7 @@ class SignedGraph:
     #
     from ._cleaners import remove_ising_clust_files
     from ._cleaners import remove_edgl_file
+    from ._cleaners import remove_adj_file
     from ._cleaners import remove_eigV_file
     from ._cleaners import remove_exported_files
     from ._cleaners import clean_gclutil

--- a/src/lrgsglib/nx_patches/SignedGraph/_cleaners.py
+++ b/src/lrgsglib/nx_patches/SignedGraph/_cleaners.py
@@ -15,9 +15,14 @@ def remove_edgl_file(self: "SignedGraph"):
 def remove_eigV_file(self: "SignedGraph"):
     os.remove(self.eigVPname)
 
+def remove_adj_file(self: "SignedGraph"):
+    os.remove(self.path_exp_adj)
+
 def remove_exported_files(self: "SignedGraph"):
     if hasattr(self, "path_exp_edgl"):
         self.remove_edgl_file()
+    if hasattr(self, "path_exp_adj"):
+        self.remove_adj_file()
     if hasattr(self, "eigVPname"):
         self.remove_eigV_file()
     if hasattr(self, "clPname"):

--- a/src/lrgsglib/nx_patches/SignedGraph/_exports.py
+++ b/src/lrgsglib/nx_patches/SignedGraph/_exports.py
@@ -141,6 +141,34 @@ def _export_edgel_bin(
                 for edge in edges:
                     assert len(edge) == 3, "Edge must be: (i, j, w_ij)"
                     f.write(struct.pack("QQd", *edge))
+
+
+def export_adj_bin(
+        self,
+        exName: str = '',
+        *,
+        on_g: str = SG_REPR,
+        upper_triangle: bool = True,
+) -> None:
+    """Export the adjacency matrix of the active graph representation."""
+
+    adj_matrix = self.get_adjacency_matrix(on_g=on_g)
+    if adj_matrix is None:
+        self.upd_graph_matrices(on_g=on_g)
+        adj_matrix = self.get_adjacency_matrix(on_g=on_g)
+    if adj_matrix is None:
+        raise RuntimeError("Adjacency matrix is not available for export.")
+
+    dense_adj = adj_matrix.toarray() if hasattr(adj_matrix, "toarray") else np.asarray(adj_matrix)
+    dense_adj = np.asarray(dense_adj, dtype=np.float64)
+    self.path_exp_adj = self.path_graph / self.get_p_fname('adj', out_suffix=exName)
+
+    with open(self.path_exp_adj, "wb") as f:
+        if upper_triangle:
+            for i in range(dense_adj.shape[0]):
+                dense_adj[i, i:].tofile(f)
+        else:
+            dense_adj.tofile(f)
 #
 # def export_adj_bin(self, verbose: bool = False) -> None:
 #     rowarr = [row[i:] for i, row in enumerate(self.adjacency_matrix.toarray())]

--- a/src/lrgsglib/statsys/BinDynSys.py
+++ b/src/lrgsglib/statsys/BinDynSys.py
@@ -1,6 +1,7 @@
 import random
 import time
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -40,13 +41,15 @@ class BinDynSys:
         self.rndStr = rndStr
         self.run_id = join_non_empty(
             '_',
-            id_string, 
+            id_string,
             self.rand_str if rndStr else ''
         )
         self.out_suffix = out_suffix
         self.pflip_id = peq_fstr(self.sg.pflip)
         self.field =  field if field is not None else ZERO_FIELD(self.N)
         self.simtime = simpref * self.N
+        base_dynpath = getattr(self.sg, "path_ising", getattr(self.sg, "path_data", Path.cwd()))
+        self.dynpath = Path(base_dynpath)
     
     @property
     def N(self) -> int:
@@ -132,10 +135,10 @@ class BinDynSys:
         raise NotImplementedError("Subclasses must implement this method")
     #
     def export_s_init(self):
-        self.sfout = self.sg.path_ising / self.sg.get_p_fname('s', self.run_id)
+        self.sfout = self.dynpath / self.sg.get_p_fname('s', self.run_id)
         self.s.astype('int8').tofile(open(self.sfout, 'wb'))
         self.s_0 = self.s.copy()
     #
     def export_hfield(self):
-        self.hfout =  self.sg.path_ising /  self.sg.get_p_fname('h', self.run_id)
+        self.hfout =  self.dynpath /  self.sg.get_p_fname('h', self.run_id)
         self.field.astype('float64').tofile(open(self.hfout, 'wb'))

--- a/src/lrgsglib/statsys/VoterModel.py
+++ b/src/lrgsglib/statsys/VoterModel.py
@@ -1,59 +1,219 @@
-from .common import *
+"""Voter-model dynamics on signed graphs."""
+
+from __future__ import annotations
+
+import random
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import tqdm
+
 from .BinDynSys import BinDynSys
+from ..config.const import LOG, LRGSG_CCORE_BIN, LRGSG_LOG
+from ..utils.basic.strings import join_non_empty
+from ..utils.tools.chronometer import time_function_accumulate
+
 
 class VoterModel(BinDynSys):
+    """Binary voter dynamics with optional C backend."""
+
     dyn_UVclass = "voter_model"
-    eqSTEP_def = 10
-    id_string_voterdyn = ""
+    magn: list[float] = []
+    s_t: list[np.ndarray] = []
 
-    def __init__(self, sg: SignedGraph = Lattice2D, **kwargs) -> None:
-        self.sg = sg
-        self.dynpath = self.path_voter
-        super(BinDynSys, self).__init__(self.sg, **kwargs)
+    def __init__(
+        self,
+        sg,
+        *,
+        eqSTEP: int = 20,
+        save_magnetization: bool = False,
+        upd_mode: str = "asynchronous",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(sg, **kwargs)
+        self.eqSTEP = int(eqSTEP)
+        self.save_magnetization = save_magnetization
+        self.upd_mode = upd_mode
+        self.dynpath = Path(getattr(self.sg, "path_voter", self.dynpath))
+        self.reset_observables()
+        self.sini: np.ndarray | None = None
+        self.stderr_path: Path | None = None
+        self.stderr_fopen = None
+        self.cprogram: list[str | Path] = []
+        self.out_id: str = self.out_suffix
+        self.magn_path: Path | None = None
 
-    def ds1step(self, nd: int):
-        nodedict = dict(self.sg.H[nd])
-        neighs = list(nodedict.keys())
-        nn = np.random.choice(neighs)
-        self.s[nd] = nodedict[nn]["weight"] * self.s[nn]
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def reset_observables(self) -> None:
+        """Reset cached observables collected during a run."""
 
-    def run_py(self):
+        self.magn = []
+        self.s_t = []
+
+    def init_voter_dynamics(self, custom: Any = None, exName: str = "") -> None:
+        """Initialise the spin configuration and export data if required."""
+
+        self.reset_observables()
+        self.init_s(custom)
+        self.s = self.s.astype(np.int8, copy=False)
+        if self.runlang.startswith("C"):
+            self.build_cprogram_command()
+            self.setup_stderr_logging()
+            self.export_s_init()
+            if self.rndStr and not exName:
+                exName = self.run_id
+            self.sg._export_edgel_bin(exName=self.run_id)
+            self.sg.export_adj_bin(exName=self.run_id)
+        self.sini = self.s.copy()
+
+    def check_attribute(self) -> None:
+        try:
+            getattr(self, "CbaseName")
+        except AttributeError:
+            self.init_voter_dynamics()
+
+    def initialize_run_parameters(self, eqSTEP: int | None = None) -> None:
+        if eqSTEP is not None:
+            self.eqSTEP = int(eqSTEP)
+        self.simtime = self.eqSTEP
+
+    # ------------------------------------------------------------------
+    # Python dynamics
+    # ------------------------------------------------------------------
+    def ds1step(self, nd: int) -> None:
+        neigh = self.sg.gr[self.sg.on_g][nd]
+        if not neigh:
+            return
+        neighbours = list(neigh)
+        choice = neighbours[np.random.randint(len(neighbours))]
+        weight = neigh[choice].get("weight", 1.0)
+        edge_sign = -1 if weight < 0 else 1
+        self.s[nd] = np.int8(edge_sign * self.s[choice])
+
+    def voter_sampling(self, tqdm_on: bool) -> None:
         dsNstep = self.dsNstep()
-        nodes = list(self.sg.H.nodes())
-        for _ in range(self.simtime):
-            smp = random.sample(nodes, self.sg.N)
-            self.s_t.append(self.s.copy())
-            # self.ds1step(np.random.randint(self.sg.N))
-            dsNstep(smp)
-    
-    def run_c(self,
-              adjfname: str = "",
-              out_suffix: str = "",
-              eqSTEP: int = 0):
-        if eqSTEP:
-            self.eqSTEP_def = eqSTEP
-        if adjfname == "":
-            adjfname = self.sg.std_fname
-        out_suffix = out_suffix + self.id_string_voterdyn
-        if out_suffix == "":
-            out_suffix = '\'\''
+        nodes = list(self.sg.gr[self.sg.on_g].nodes())
+        iterator = tqdm.tqdm(range(self.eqSTEP)) if tqdm_on else range(self.eqSTEP)
+        for _ in iterator:
+            if self.save_magnetization:
+                self.magn.append(float(np.sum(self.s)) / float(self.N))
+            if self.savedyn:
+                self.s_t.append(self.s.copy())
+            dsNstep(random.sample(nodes, len(nodes)))
+
+    def run_py(self, tqdm_on: bool = False) -> None:
+        self.voter_sampling(tqdm_on)
+
+    # ------------------------------------------------------------------
+    # C backend integration
+    # ------------------------------------------------------------------
+    def build_cprogram_command(self) -> None:
+        self.CbaseName = "voter_model"
+        try:
+            datdir = self.sg.path_sgdata.relative_to(Path.cwd())
+        except ValueError:
+            datdir = self.sg.path_sgdata
+        syshape = getattr(self.sg, "syshapePth", f"N={self.N}")
+        self.out_id = self.out_suffix
+        self.magn_path = self.dynpath / self.sg.get_p_fname('m', self.out_id)
         self.cprogram = [
-            # pth_join(DIR_SRC, DIR_PCK, self.dyn_UVclass),
-            # f"{DIR_SRC_DEFAULT}{DIR_PCK_DEFAULT}{self.dyn_UVclass}",
-            f"{self.sg.N}",
-            f"{self.sg.pflip}",
-            f"{self.eqSTEP_def}",
-            str(self.sg.path_plot),
-            adjfname,
-            out_suffix
+            LRGSG_CCORE_BIN / self.CbaseName,
+            f"{self.N}",
+            f"{self.sg.pflip:.12g}",
+            f"{self.eqSTEP}",
+            str(datdir),
+            syshape,
+            self.run_id,
+            self.out_id,
         ]
-        subprocess.call(self.cprogram)
 
-    def run(self, **kwargs):
-        if self.runlang.startswith("py"):
-            self.run_py()
-        elif self.runlang.startswith("C"):
-            self.run_c(**kwargs)
+    def setup_stderr_logging(self) -> None:
+        fname = join_non_empty(
+            '_',
+            "errVoterModel",
+            f"{self.N}",
+            self.run_id,
+            self.out_suffix,
+        ) + LOG
+        self.stderr_path = LRGSG_LOG / fname
+        self.stderr_path.parent.mkdir(parents=True, exist_ok=True)
+        self.stderr_fopen = open(self.stderr_path, 'w')
 
+    def run_cprogram(self, verbose: bool = False) -> None:
+        if not self.cprogram:
+            raise RuntimeError("C program command has not been initialised.")
+        binary_path = Path(self.cprogram[0])
+        if not binary_path.exists():
+            if self.stderr_fopen and not self.stderr_fopen.closed:
+                self.stderr_fopen.close()
+            raise FileNotFoundError(
+                f"C backend executable '{binary_path}' was not found. Build the "
+                "C components (e.g. via `make c-make`) before running the C backend."
+            )
+        result = subprocess.run(
+            self.cprogram,
+            stderr=self.stderr_fopen,
+            stdout=subprocess.PIPE,
+            check=False,
+        )
+        if self.stderr_fopen and not self.stderr_fopen.closed:
+            self.stderr_fopen.close()
+        state = np.frombuffer(result.stdout, dtype=np.int8)
+        if state.size != self.N:
+            raise RuntimeError("C backend returned an invalid spin configuration.")
+        self.s = state.copy()
+        if self.magn_path and self.magn_path.exists():
+            self.magn = np.fromfile(self.magn_path, dtype=np.float64).tolist()
 
+    def _remove_sfout(self) -> None:
+        try:
+            self.sfout.unlink()
+        except FileNotFoundError:
+            pass
 
+    def _remove_magn(self) -> None:
+        if not self.magn_path:
+            return
+        try:
+            self.magn_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def _remove_stderr(self) -> None:
+        if not self.stderr_path:
+            return
+        try:
+            self.stderr_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def remove_run_c_files(self, remove_stderr: bool = True) -> None:
+        self._remove_sfout()
+        self._remove_magn()
+        if remove_stderr:
+            self._remove_stderr()
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+    @time_function_accumulate(auto_log=False)
+    def run(
+        self,
+        tqdm_on: bool = True,
+        eqSTEP: int | None = None,
+        verbose: bool = False,
+        clean_export: bool = True,
+    ) -> None:
+        self.check_attribute()
+        self.initialize_run_parameters(eqSTEP)
+        if self.runlang.startswith("C"):
+            self.run_cprogram(verbose)
+            if clean_export:
+                self.remove_run_c_files()
+                self.sg.remove_exported_files()
+        else:
+            self.voter_sampling(tqdm_on)

--- a/test/test_voter_model.py
+++ b/test/test_voter_model.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+nx = pytest.importorskip("networkx")
+
+
+class TestVoterModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp_dir = tempfile.TemporaryDirectory()
+        base_dir = Path(cls._tmp_dir.name)
+        cls.data_dir = base_dir / "data"
+        cls.log_dir = base_dir / "log"
+        cls.data_dir.mkdir(parents=True, exist_ok=True)
+        cls.log_dir.mkdir(parents=True, exist_ok=True)
+        cls.ccore_dir = base_dir / "Ccore" / "bin"
+        cls.ccore_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["LRGSG_CCORE_BIN"] = str(cls.ccore_dir)
+
+        cls.src_path = Path(__file__).resolve().parents[1] / "src"
+        sys.path.insert(0, str(cls.src_path))
+
+        env_module = types.ModuleType("lrgsglib.config.lrgsg_env")
+        env_module.LRGSG_LLIB = str(cls.src_path / "lrgsglib")
+        env_module.LRGSG_DATA = str(cls.data_dir)
+        env_module.LRGSG_LOG = str(cls.log_dir)
+        env_module.LRGSG_CCORE_BIN = str(cls.ccore_dir)
+        sys.modules["lrgsglib.config.lrgsg_env"] = env_module
+
+        from lrgsglib.nx_patches import SignedGraph
+        from lrgsglib.statsys.VoterModel import VoterModel
+
+        cls.SignedGraph = SignedGraph
+        cls.VoterModel = VoterModel
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp_dir.cleanup()
+        if str(cls.src_path) in sys.path:
+            sys.path.remove(str(cls.src_path))
+
+    def _make_graph(self):
+        G = nx.Graph()
+        edges = [
+            (0, 1, 1.0),
+            (1, 2, -1.0),
+            (2, 3, 1.0),
+            (3, 0, 1.0),
+        ]
+        for u, v, w in edges:
+            G.add_edge(u, v, weight=w)
+        return self.SignedGraph(
+            G,
+            pflip=0.0,
+            init_nw_dict=False,
+            path_data=self.data_dir,
+            path_plot=self.log_dir,
+        )
+
+    def test_python_dynamics_collects_history(self):
+        sg = self._make_graph()
+        model = self.VoterModel(
+            sg,
+            runlang="py",
+            savedyn=True,
+            save_magnetization=True,
+            eqSTEP=5,
+            seed=123,
+        )
+        model.run(tqdm_on=False)
+        self.assertEqual(len(model.magn), 5)
+        self.assertEqual(len(model.s_t), 5)
+        self.assertTrue(np.all(np.isin(model.s, (-1, 1))))
+
+    def test_init_voter_dynamics_exports_required_files(self):
+        sg = self._make_graph()
+        model = self.VoterModel(sg, runlang="C", eqSTEP=2, seed=0)
+        model.init_voter_dynamics()
+        try:
+            self.assertTrue(model.sfout.exists())
+            self.assertTrue(hasattr(model.sg, "path_exp_edgl") and model.sg.path_exp_edgl.exists())
+            self.assertTrue(hasattr(model.sg, "path_exp_adj") and model.sg.path_exp_adj.exists())
+        finally:
+            if model.stderr_fopen and not model.stderr_fopen.closed:
+                model.stderr_fopen.close()
+            model.remove_run_c_files(remove_stderr=True)
+            model.sg.remove_exported_files()
+
+    def test_run_c_raises_when_binary_missing(self):
+        sg = self._make_graph()
+        model = self.VoterModel(sg, runlang="C", eqSTEP=1, seed=0)
+        model.init_voter_dynamics()
+        with self.assertRaises(FileNotFoundError):
+            model.run(tqdm_on=False, clean_export=False)
+        if model.stderr_fopen and not model.stderr_fopen.closed:
+            model.stderr_fopen.close()
+        model.remove_run_c_files(remove_stderr=True)
+        model.sg.remove_exported_files()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor `VoterModel` to reuse `BinDynSys` export paths, share observables, and dispatch to the updated C backend
- extend `SignedGraph` exports/cleaners with adjacency support and wire the voter directories through the base dynamics class
- rewrite the voter C runner to reuse shared edge processing and emit magnetisation while updating the unit tests around the new structure

## Testing
- pytest test/test_voter_model.py *(skipped: optional dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_690b57dd34b0832db628c50f283d10bb