### PR TITLE
Add activation-based contact process backend

### DIFF
--- a/build/cprogn.mk
+++ b/build/cprogn.mk
@@ -8,6 +8,7 @@ FN_RBIMSIM5 = IsingSimulator5
 FN_VMSIM0   = VoterSimulator0
 FN_VMSIM1   = VoterSimulator1
 FN_CPSIM0   = ContactSimulator0
+FN_CPSIM1   = ContactSimulator1
 FN_LRGSGLIB = LRGSG_utils sfmtrng
 SRC_BINDYNSYS = LRGSG_bindynsys
 SRC_RBIM    = LRGSG_rbim
@@ -17,7 +18,7 @@ SFMTSRC     = SFMT
 #
 FNS := $(FN_RBIMSIM0) $(FN_RBIMSIM1) $(FN_RBIMSIM2) \
        $(FN_RBIMSIM3) $(FN_RBIMSIM4) $(FN_RBIMSIM5) \
-       $(FN_VMSIM0) $(FN_VMSIM1) $(FN_CPSIM0)
+       $(FN_VMSIM0) $(FN_VMSIM1) $(FN_CPSIM0) $(FN_CPSIM1)
 # only these go into PROGS
 PROGS := $(addprefix $(LRGSG_CCORE_BIN)/, $(FNS))
 # #

--- a/src/lrgsglib/Ccore/statsys/contactP/ContactSimulator1.c
+++ b/src/lrgsglib/Ccore/statsys/contactP/ContactSimulator1.c
@@ -1,0 +1,69 @@
+#include "LRGSG_cp.h"
+#include "LRGSG_utils.h"
+#include "sfmtrng.h"
+
+#define EXPECTED_ARGC (9 + 1)
+
+int main(int argc, char *argv[]) {
+    if (argc < EXPECTED_ARGC) {
+        fprintf(stderr, "Usage: %s N p gamma steps datdir syshape run_id out_id activation\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    __set_seed_SFMT();
+
+    char *ptr;
+    size_t N = strtozu(argv[1]);
+    double p = strtod(argv[2], &ptr);
+    double gamma = strtod(argv[3], &ptr);
+    size_t steps = strtozu(argv[4]);
+    const char *datdir = argv[5];
+    const char *syshape = argv[6];
+    const char *run_id = argv[7];
+    const char *out_id = argv[8];
+    const char *activation_name = argv[9];
+    (void)out_id;
+
+    cp_activation_t activation = cp_activation_from_string(activation_name);
+
+    char buf[STRL512];
+    FILE *f_sini;
+    sprintf(buf, SINI_FNAME, datdir, syshape, p, run_id);
+    __fopen(&f_sini, buf, "rb");
+    spin_tp state = __chMalloc(N * sizeof(*state));
+    __fread_check(fread(state, sizeof(*state), N, f_sini), N);
+    fclose(f_sini);
+
+    Edges edges;
+    NodesEdges node_edges;
+    size_tp neigh_len;
+    sprintf(buf, EDGL_FNAME, datdir, syshape, p, run_id);
+    process_edges(buf, N, &edges, &node_edges, &neigh_len);
+
+    for (size_t t = 0; t < steps; ++t) {
+        for (size_t sweep = 0; sweep < N; ++sweep) {
+            size_t node = (size_t)(RNG_u64() % N);
+            size_tp degree = neigh_len[node];
+            NodeEdges edges_node = node_edges[node];
+            double lambda = cp_linear_input(gamma, state, degree, edges_node);
+            double prob = cp_activation_probability(lambda, activation);
+            state[node] = (int8_t)(RNG_dbl() < prob);
+        }
+    }
+
+    fwrite(state, sizeof(*state), N, stdout);
+    fflush(stdout);
+
+    free(edges);
+    for (size_t i = 0; i < N; ++i) {
+        if (neigh_len[i]) {
+            free(node_edges[i].neighbors);
+            free(node_edges[i].weights);
+        }
+    }
+    free(node_edges);
+    free(neigh_len);
+    free(state);
+
+    return EXIT_SUCCESS;
+}

--- a/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.c
+++ b/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.c
@@ -1,5 +1,8 @@
 #include "LRGSG_cp.h"
 
+#include <math.h>
+#include <strings.h>
+
 double cp_infection_rate(size_t node, spin_tp state, size_tp degree, NodeEdges edges) {
     (void)node;
     double rate = 0.0;
@@ -11,6 +14,45 @@ double cp_infection_rate(size_t node, spin_tp state, size_tp degree, NodeEdges e
         }
     }
     return rate;
+}
+
+cp_activation_t cp_activation_from_string(const char *name) {
+    if (!name) {
+        return CP_ACTIVATION_TANH;
+    }
+    if (strcasecmp(name, "relu") == 0) {
+        return CP_ACTIVATION_RELU;
+    }
+    return CP_ACTIVATION_TANH;
+}
+
+double cp_linear_input(double gamma, spin_tp state, size_tp degree, NodeEdges edges) {
+    double total = 0.0;
+    for (size_t idx = 0; idx < degree; ++idx) {
+        size_t neighbour = edges.neighbors[idx];
+        double weight = edges.weights[idx];
+        total += weight * (double)state[neighbour];
+    }
+    return gamma * total;
+}
+
+double cp_activation_probability(double lambda, cp_activation_t activation) {
+    double prob;
+    switch (activation) {
+        case CP_ACTIVATION_RELU:
+            prob = lambda > 0.0 ? lambda : 0.0;
+            break;
+        case CP_ACTIVATION_TANH:
+        default:
+            prob = 0.5 * (tanh(lambda) + 1.0);
+            break;
+    }
+    if (prob < 0.0) {
+        prob = 0.0;
+    } else if (prob > 1.0) {
+        prob = 1.0;
+    }
+    return prob;
 }
 
 double cp_recovery_rate(size_t node, double mu, spin_tp state, size_tp degree, NodeEdges edges) {

--- a/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.h
+++ b/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.h
@@ -11,4 +11,13 @@
 double cp_infection_rate(size_t node, spin_tp state, size_tp degree, NodeEdges edges);
 double cp_recovery_rate(size_t node, double mu, spin_tp state, size_tp degree, NodeEdges edges);
 
+typedef enum {
+    CP_ACTIVATION_TANH = 0,
+    CP_ACTIVATION_RELU = 1
+} cp_activation_t;
+
+cp_activation_t cp_activation_from_string(const char *name);
+double cp_linear_input(double gamma, spin_tp state, size_tp degree, NodeEdges edges);
+double cp_activation_probability(double lambda, cp_activation_t activation);
+
 #endif /* __LRGSGCPLIB_H_INC__ */

--- a/src/lrgsglib/statsys/BinDynSys.py
+++ b/src/lrgsglib/statsys/BinDynSys.py
@@ -1,12 +1,15 @@
+"""Base classes and helpers for binary dynamical systems."""
+
+from __future__ import annotations
+
+import os
 import random
 import time
-import os
 from pathlib import Path
+from typing import Any, Iterable, Literal
 
 import numpy as np
-
 from numpy.typing import NDArray
-from typing import Any, Iterable
 
 from ..config.const import *
 from ..config.funcs import peq_fstr
@@ -15,10 +18,13 @@ from ..utils.basic.strings import generate_random_id, join_non_empty
 
 ZERO_FIELD = lambda N: np.zeros(N, dtype=np.float64)
 
+StateType = Literal["bipolar", "binary"]
+
+
 class BinDynSys:
-    s_t = []
-    dynpath = ''
-    run_id = ''
+    s_t: list[np.ndarray] = []
+    dynpath: Path | str = ""
+    run_id: str = ""
 
     def __init__(
         self,
@@ -33,6 +39,8 @@ class BinDynSys:
         id_string: str = "",
         out_suffix: str = "",
         dynpath: Path = None,
+        *,
+        state_type: StateType = "bipolar",
     ):
         self.__init_randomness__(seed)
         self.sg = sg
@@ -47,17 +55,45 @@ class BinDynSys:
         )
         self.out_suffix = out_suffix
         self.pflip_id = peq_fstr(self.sg.pflip)
-        self.field =  field if field is not None else ZERO_FIELD(self.N)
+        self.field = field if field is not None else ZERO_FIELD(self.N)
         self.simtime = simpref * self.N
         if dynpath is None:
             base_dynpath = getattr(self.sg, "path_data", Path.cwd())
             self.dynpath = Path(base_dynpath)
         else:
             self.dynpath = Path(dynpath)
+        self._set_state_type(state_type)
+        self.s: np.ndarray = np.zeros(self.N, dtype=np.int8)
     
     @property
     def N(self) -> int:
         return self.sg.N
+
+    def _set_state_type(self, state_type: StateType) -> None:
+        if state_type not in {"bipolar", "binary"}:
+            raise ValueError("state_type must be either 'bipolar' or 'binary'.")
+        self._state_type: StateType = state_type
+
+    @property
+    def state_type(self) -> StateType:
+        return self._state_type
+
+    @property
+    def inactive_state(self) -> int:
+        return -1 if self.state_type == "bipolar" else 0
+
+    @property
+    def active_state(self) -> int:
+        return 1
+
+    def _coerce_custom_state(self, custom: Any) -> np.ndarray:
+        arr = np.asarray(custom, dtype=np.int8)
+        if arr.shape != (self.sg.N,):
+            raise ValueError("Custom state must match the number of nodes in the graph.")
+        valid_values = {self.inactive_state, self.active_state}
+        if not set(np.unique(arr)).issubset(valid_values):
+            raise ValueError("Custom state contains values incompatible with the chosen state_type.")
+        return arr
     #
     def __init_randomness__(self, seed: int = None) -> None:
         """
@@ -101,27 +137,45 @@ class BinDynSys:
                                  object has no attribute '{attr_name}'")
     #
     def flip_spin(self, nd: int) -> None:
-        self.s[nd] *= -1
+        if self.state_type == "bipolar":
+            self.s[nd] = np.int8(-self.s[nd])
+        else:
+            self.s[nd] = np.int8(self.active_state if self.s[nd] == self.inactive_state else self.inactive_state)
     #
-    def init_s(self, custom: Any = None):
+    def init_s(self, custom: Any = None) -> None:
+        inactive = self.inactive_state
+        active = self.active_state
         match self.ic:
-            case 'uniform'|'random'| 'rand':
-                self.s = np.random.choice([-1, 1], size=self.sg.N)
+            case "uniform" | "random" | "rand":
+                self.s = np.random.choice([inactive, active], size=self.sg.N)
             case _ if self.ic.startswith(("gs", "ground_state")):
-                self.n_eigV = int(self.ic.split("_")[-1])
-                self.s = self.sg.get_eigV_bin_check(which=self.n_eigV).copy()
-            case 'custom':
-                self.s = custom
-            case 'homogeneous'|'homo':
-                self.s = np.ones(self.sg.N)
-            case 'delta':
-                self.s = -np.ones(self.sg.N)
-                self.s[np.random.randint(self.sg.N)] = 1
-            case _ if self.ic.startswith('mult_rand'|'deltas'):
-                num = int(self.ic.split('_')[-1])
-                self.s[np.random.randint(self.sg.N, size=num)]
+                idx = int(self.ic.split("_")[-1])
+                eig_state = self.sg.get_eigV_bin_check(which=idx).copy()
+                if self.state_type == "binary":
+                    self.s = np.where(eig_state > 0, active, inactive)
+                else:
+                    self.s = eig_state
+            case "custom":
+                if custom is None:
+                    raise ValueError("A custom state must be provided for 'custom' initial condition.")
+                self.s = self._coerce_custom_state(custom)
+            case "homogeneous" | "homo":
+                self.s = np.full(self.sg.N, active, dtype=np.int8)
+            case "delta":
+                self.s = np.full(self.sg.N, inactive, dtype=np.int8)
+                self.s[np.random.randint(self.sg.N)] = active
+            case _ if self.ic.startswith("mult_rand") or self.ic.startswith("deltas"):
+                try:
+                    num = int(self.ic.split("_")[-1])
+                except (IndexError, ValueError) as exc:
+                    raise ValueError("Invalid 'mult_rand' specification.") from exc
+                num = max(1, min(num, self.sg.N))
+                self.s = np.full(self.sg.N, inactive, dtype=np.int8)
+                indices = np.random.choice(self.sg.N, size=num, replace=False)
+                self.s[indices] = active
             case _:
                 raise ValueError("Invalid initial condition.")
+        self.s = np.asarray(self.s, dtype=np.int8)
 
     def ds1step(self, nd: int):
         raise NotImplementedError("Subclasses must implement this method")

--- a/src/lrgsglib/statsys/ContactProcess.py
+++ b/src/lrgsglib/statsys/ContactProcess.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Literal, cast
 
 import numpy as np
 import tqdm
@@ -28,14 +28,24 @@ class ContactProcess(BinDynSys):
         sg: SignedGraph,
         mu: float = 1.0,
         *,
+        gamma: float | None = None,
+        activation: Literal["tanh", "relu"] = "tanh",
         save_density: bool = False,
+        state_type: Literal["binary", "bipolar"] | None = None,
         **kwargs: Any,
     ) -> None:
         dynpath = getattr(sg, "path_contact", None)
         if dynpath is None:
             dynpath = getattr(sg, "path_lrgsg", getattr(sg, "path_data", Path.cwd()))
-        super().__init__(sg, dynpath=dynpath, **kwargs)
+        super().__init__(
+            sg,
+            dynpath=dynpath,
+            state_type=state_type or "binary",
+            **kwargs,
+        )
         self.mu = float(mu)
+        self.gamma = float(gamma) if gamma is not None else None
+        self.activation = self._validate_activation(activation)
         self.save_density = save_density
         self.reset_observables()
         self.sini: np.ndarray | None = None
@@ -72,7 +82,7 @@ class ContactProcess(BinDynSys):
         """Initialise the state and export data if required."""
 
         self.reset_observables()
-        self.init_state(custom)
+        self.init_s(custom)
         self.s = self.s.astype(np.int8, copy=False)
         if self.runlang.startswith("C"):
             self.build_cprogram_command()
@@ -81,23 +91,9 @@ class ContactProcess(BinDynSys):
             if self.rndStr and not exName:
                 exName = self.run_id
             self.sg._export_edgel_bin(exName=self.run_id)
+            if self._c_program_key() == "C1":
+                self.sg.export_adj_bin(exName=self.run_id)
         self.sini = self.s.copy()
-
-    def init_state(self, custom: Any = None) -> None:
-        match self.ic:
-            case "uniform" | "random" | "rand":
-                self.s = np.random.choice([0, 1], size=self.sg.N).astype(np.int8)
-            case "homogeneous" | "homo":
-                self.s = np.ones(self.sg.N, dtype=np.int8)
-            case "delta":
-                self.s = np.zeros(self.sg.N, dtype=np.int8)
-                self.s[np.random.randint(self.sg.N)] = 1
-            case "custom":
-                if custom is None:
-                    raise ValueError("A custom state must be provided for 'custom' initial condition.")
-                self.s = np.asarray(custom, dtype=np.int8)
-            case _:
-                raise ValueError("Invalid initial condition for ContactProcess.")
 
     def check_attribute(self) -> None:
         try:
@@ -149,15 +145,37 @@ class ContactProcess(BinDynSys):
     # ------------------------------------------------------------------
     # C backend integration
     # ------------------------------------------------------------------
-    def build_cprogram_command(self) -> None:
-        self.CbaseName = f"ContactSimulator{self.runlang[-1]}"
+    def _c_program_key(self) -> str:
+        if not self.runlang or not self.runlang.upper().startswith("C"):
+            raise ValueError("C backend requested but runlang is not a C variant.")
+        suffix = self.runlang[1:]
+        return "C0" if suffix == "" else f"C{suffix}"
+
+    def _validate_activation(self, activation: str) -> Literal["tanh", "relu"]:
+        normalized = activation.lower()
+        if normalized not in {"tanh", "relu"}:
+            raise ValueError("activation must be either 'tanh' or 'relu'.")
+        return cast(Literal["tanh", "relu"], normalized)
+
+    def _build_c_arglist(self) -> list[str]:
+        builders = {
+            "C0": self._build_c_arglist_c0,
+            "C1": self._build_c_arglist_c1,
+        }
+        key = self._c_program_key()
+        try:
+            return builders[key]()
+        except KeyError as exc:
+            raise ValueError(f"Unsupported C program key '{key}'.") from exc
+
+    def _build_c_arglist_c0(self) -> list[str]:
         try:
             datdir = self.sg.path_sgdata.relative_to(Path.cwd())
         except ValueError:
             datdir = self.sg.path_sgdata
         syshape = getattr(self.sg, "syshapePth", f"N={self.N}")
         self.out_id = self.out_suffix
-        arglist = [
+        return [
             f"{self.N}",
             f"{self.sg.pflip:.12g}",
             f"{self.mu:.12g}",
@@ -167,6 +185,32 @@ class ContactProcess(BinDynSys):
             self.run_id,
             self.out_id,
         ]
+
+    def _build_c_arglist_c1(self) -> list[str]:
+        if self.gamma is None:
+            raise ValueError("gamma must be provided when using runlang 'C1'.")
+        try:
+            datdir = self.sg.path_sgdata.relative_to(Path.cwd())
+        except ValueError:
+            datdir = self.sg.path_sgdata
+        syshape = getattr(self.sg, "syshapePth", f"N={self.N}")
+        self.out_id = self.out_suffix
+        return [
+            f"{self.N}",
+            f"{self.sg.pflip:.12g}",
+            f"{self.gamma:.12g}",
+            f"{self.simtime}",
+            str(datdir),
+            syshape,
+            self.run_id,
+            self.out_id,
+            self.activation,
+        ]
+
+    def build_cprogram_command(self) -> None:
+        c_key = self._c_program_key()
+        self.CbaseName = f"ContactSimulator{c_key[-1]}"
+        arglist = self._build_c_arglist()
         self.cprogram = [LRGSG_CCORE_BIN / self.CbaseName] + arglist
 
     def setup_stderr_logging(self) -> None:

--- a/test/test_contact_process.py
+++ b/test/test_contact_process.py
@@ -1,0 +1,106 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+nx = pytest.importorskip("networkx")
+
+
+class TestContactProcess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp_dir = tempfile.TemporaryDirectory()
+        base_dir = Path(cls._tmp_dir.name)
+        cls.data_dir = base_dir / "data"
+        cls.log_dir = base_dir / "log"
+        cls.data_dir.mkdir(parents=True, exist_ok=True)
+        cls.log_dir.mkdir(parents=True, exist_ok=True)
+        cls.ccore_dir = base_dir / "Ccore" / "bin"
+        cls.ccore_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["LRGSG_CCORE_BIN"] = str(cls.ccore_dir)
+
+        cls.src_path = Path(__file__).resolve().parents[1] / "src"
+        sys.path.insert(0, str(cls.src_path))
+
+        env_module = types.ModuleType("lrgsglib.config.lrgsg_env")
+        env_module.LRGSG_LLIB = str(cls.src_path / "lrgsglib")
+        env_module.LRGSG_DATA = str(cls.data_dir)
+        env_module.LRGSG_LOG = str(cls.log_dir)
+        env_module.LRGSG_CCORE_BIN = str(cls.ccore_dir)
+        sys.modules["lrgsglib.config.lrgsg_env"] = env_module
+
+        from lrgsglib.nx_patches import SignedGraph
+        from lrgsglib.statsys.ContactProcess import ContactProcess
+
+        cls.SignedGraph = SignedGraph
+        cls.ContactProcess = ContactProcess
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp_dir.cleanup()
+        if str(cls.src_path) in sys.path:
+            sys.path.remove(str(cls.src_path))
+
+    def _make_graph(self):
+        G = nx.Graph()
+        edges = [
+            (0, 1, 1.0),
+            (1, 2, -1.0),
+            (2, 3, 1.0),
+            (3, 0, 0.5),
+        ]
+        for u, v, w in edges:
+            G.add_edge(u, v, weight=w)
+        return self.SignedGraph(
+            G,
+            pflip=0.0,
+            init_nw_dict=False,
+            path_data=self.data_dir,
+            path_plot=self.log_dir,
+        )
+
+    def test_init_contact_dynamics_uses_binary_state(self):
+        sg = self._make_graph()
+        model = self.ContactProcess(sg, runlang="py", ic="uniform", seed=123, simpref=1)
+        model.init_contact_dynamics()
+        try:
+            unique = np.unique(model.s)
+            self.assertTrue(np.all(np.isin(unique, (0, 1))))
+        finally:
+            model.reset_observables()
+
+    def test_c1_builder_exports_and_arguments(self):
+        sg = self._make_graph()
+        model = self.ContactProcess(
+            sg,
+            runlang="C1",
+            gamma=0.5,
+            activation="relu",
+            seed=0,
+            simpref=1,
+        )
+        model.init_contact_dynamics()
+        try:
+            self.assertTrue(model.sfout.exists())
+            self.assertTrue(hasattr(model.sg, "path_exp_edgl") and model.sg.path_exp_edgl.exists())
+            self.assertTrue(hasattr(model.sg, "path_exp_adj") and model.sg.path_exp_adj.exists())
+            expected_binary = self.ccore_dir / "ContactSimulator1"
+            self.assertEqual(Path(model.cprogram[0]), expected_binary)
+            self.assertEqual(model.cprogram[1], str(model.N))
+            self.assertEqual(model.cprogram[2], f"{model.sg.pflip:.12g}")
+            self.assertEqual(model.cprogram[3], f"{model.gamma:.12g}")
+            self.assertEqual(model.cprogram[-1], model.activation)
+        finally:
+            if model.stderr_fopen and not model.stderr_fopen.closed:
+                model.stderr_fopen.close()
+            model.remove_run_c_files(remove_stderr=True)
+            model.sg.remove_exported_files()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- teach `BinDynSys` to initialise binary or bipolar states and reuse it inside the contact process
- add the C1 contact-process backend with selectable activation functions and shared argument builders
- register the new binary in the build rules and cover the Python-side wiring with unit tests

## Testing
- pytest test/test_contact_process.py test/test_voter_model.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f17d31e0832d990ca50b82345fa5)