### PR TITLE
Cache Gillespie selector dispatch

### DIFF
--- a/build/cprogn.mk
+++ b/build/cprogn.mk
@@ -13,6 +13,8 @@ FN_CPSIM1A  = ContactSimulator1a
 FN_CPSIM1B  = ContactSimulator1b
 FN_CPSIM1C  = ContactSimulator1c
 FN_CPSIM1D  = ContactSimulator1d
+FN_CPSIM1E  = ContactSimulator1e
+FN_CPSIM1F  = ContactSimulator1f
 FN_LRGSGLIB = LRGSG_utils sfmtrng
 SRC_BINDYNSYS = LRGSG_bindynsys
 SRC_RBIM    = LRGSG_rbim
@@ -23,7 +25,7 @@ SFMTSRC     = SFMT
 FNS := $(FN_RBIMSIM0) $(FN_RBIMSIM1) $(FN_RBIMSIM2) \
        $(FN_RBIMSIM3) $(FN_RBIMSIM4) $(FN_RBIMSIM5) \
        $(FN_VMSIM0) $(FN_VMSIM1) $(FN_CPSIM0) $(FN_CPSIM1) \
-       $(FN_CPSIM1A) $(FN_CPSIM1B) $(FN_CPSIM1C) $(FN_CPSIM1D)
+       $(FN_CPSIM1A) $(FN_CPSIM1B) $(FN_CPSIM1C) $(FN_CPSIM1D) $(FN_CPSIM1E) $(FN_CPSIM1F)
 # only these go into PROGS
 PROGS := $(addprefix $(LRGSG_CCORE_BIN)/, $(FNS))
 # #

--- a/src/lrgsglib/Ccore/statsys/contactP/ContactSimulator1e.c
+++ b/src/lrgsglib/Ccore/statsys/contactP/ContactSimulator1e.c
@@ -4,7 +4,6 @@
 #include <math.h>
 
 #define EXPECTED_ARGC (10 + 1)
-#define FRONTIER_DENSITY_THRESHOLD 0.15
 
 int main(int argc, char *argv[]) {
     if (argc < EXPECTED_ARGC) {
@@ -49,21 +48,13 @@ int main(int argc, char *argv[]) {
     double *lambda = __chMalloc(N * sizeof(*lambda));
     cp_lambda_init(gamma, state, N, node_edges, neigh_len, lambda);
 
-    /* Allocate density array */
+    /* Allocate density array - will be filled by Python's log-spaced indices */
     double *density = __chCalloc(num_log_samples, sizeof(double));
 
     /* Open output file for density time series */
     FILE *f_dens;
     sprintf(buf, DENS_FNAME, datdir, syshape, p, out_id);
     __fopen(&f_dens, buf, "wb");
-
-    /* Initialize frontier tracking */
-    cp_frontier_t frontier;
-    cp_frontier_init(&frontier, N);
-    frontier.use_lambda_boundary = (activation == CP_ACTIVATION_RELU);
-
-    /* Build initial frontier from state */
-    cp_frontier_build(&frontier, state, lambda, N, node_edges, neigh_len);
 
     /* Calculate initial density */
     size_t sum = 0;
@@ -74,73 +65,51 @@ int main(int argc, char *argv[]) {
     size_t sample_idx = 0;
     density[sample_idx++] = (double)sum / (double)N;
 
-    fprintf(stderr, "Initial: density=%.6f, active=%zu, boundary=%zu, threshold=%.2f\n",
-            density[0], frontier.active_count, frontier.boundary_count, FRONTIER_DENSITY_THRESHOLD);
+    fprintf(stderr, "Initial density: %.6f, will save %zu samples\n", density[0], num_log_samples);
 
-    /* Get activation function pointer once */
-    cp_activation_func_t activation_func = cp_get_activation_function(activation);
-    double invN = 1.0 / (double)N;
-
-    cp_frontier_sim_t sim = {
+    /* Build simulation context */
+    cp_cached_sim_t sim = {
         .gamma = gamma,
         .N = N,
         .state = state,
         .lambda = lambda,
         .node_edges = node_edges,
         .neigh_len = neigh_len,
-        .frontier = &frontier,
-        .activation_func = activation_func,
+        .activation_func = cp_get_activation_function(activation),
     };
 
-    /* Simulation loop */
+    /* Simulation loop - save density every step */
     size_t t;
     for (t = 0; t < steps; ++t) {
-        /* Check for absorbing state */
         if (cp_reached_absorbing_state(sum, N, t, steps)) {
             break;
         }
 
-        /* Adaptive algorithm selection based on density */
-        double current_density = (double)sum * invN;
-        int use_frontier = (current_density < FRONTIER_DENSITY_THRESHOLD);
+        (void)cp_run_sweep_cached(&sim, &sum);
 
-        if (use_frontier) {
-            /* Low density: use frontier optimization */
-            cp_frontier_sweep_result_t frontier_result = cp_run_frontier_sweep(&sim, &sum);
-            if (frontier_result.frontier_size == 0) {
-                fprintf(stderr, "Reached absorbing state at t=%zu (empty frontier)\n", t);
-                break;
-            }
-        } else {
-            /* High density: use standard random sampling */
-            (void)cp_run_dense_frontier_sweep(&sim, &sum);
-        }
-
-        /* Save density */
         if (sample_idx < num_log_samples) {
             density[sample_idx++] = (double)sum / (double)N;
         }
     }
 
-    /* Fill remaining samples with final density if ended early */
+    /* Fill remaining samples with final density if simulation ended early */
     double final_density = (double)sum / (double)N;
     while (sample_idx < num_log_samples) {
         density[sample_idx++] = final_density;
     }
 
-    fprintf(stderr, "Complete: t=%zu, density=%.6f, active=%zu, boundary=%zu\n",
-            t, final_density, frontier.active_count, frontier.boundary_count);
+    fprintf(stderr, "Simulation complete: %zu steps, final density=%.6f\n", t, final_density);
 
-    /* Write outputs */
+    /* Write density values as simple array */
     fwrite(density, sizeof(double), num_log_samples, f_dens);
     fclose(f_dens);
 
+    /* Write final state to stdout */
     fwrite(state, sizeof(*state), N, stdout);
     fflush(stdout);
 
     /* Cleanup */
     free(density);
-    cp_frontier_free(&frontier);
     free(lambda);
     free(edges);
     for (size_t i = 0; i < N; ++i) {

--- a/src/lrgsglib/Ccore/statsys/contactP/ContactSimulator1f.c
+++ b/src/lrgsglib/Ccore/statsys/contactP/ContactSimulator1f.c
@@ -2,9 +2,9 @@
 #include "LRGSG_utils.h"
 #include "sfmtrng.h"
 #include <math.h>
+#include <string.h>
 
 #define EXPECTED_ARGC (10 + 1)
-#define FRONTIER_DENSITY_THRESHOLD 0.15
 
 int main(int argc, char *argv[]) {
     if (argc < EXPECTED_ARGC) {
@@ -57,13 +57,16 @@ int main(int argc, char *argv[]) {
     sprintf(buf, DENS_FNAME, datdir, syshape, p, out_id);
     __fopen(&f_dens, buf, "wb");
 
-    /* Initialize frontier tracking */
+    /* Initialize frontier tracking only when needed (ReLU benefits from boundary filtering) */
     cp_frontier_t frontier;
-    cp_frontier_init(&frontier, N);
-    frontier.use_lambda_boundary = (activation == CP_ACTIVATION_RELU);
-
-    /* Build initial frontier from state */
-    cp_frontier_build(&frontier, state, lambda, N, node_edges, neigh_len);
+    int use_frontier = (activation == CP_ACTIVATION_RELU);
+    if (use_frontier) {
+        cp_frontier_init(&frontier, N);
+        frontier.use_lambda_boundary = 1;
+        cp_frontier_build(&frontier, state, lambda, N, node_edges, neigh_len);
+    } else {
+        memset(&frontier, 0, sizeof(frontier));
+    }
 
     /* Calculate initial density */
     size_t sum = 0;
@@ -74,62 +77,63 @@ int main(int argc, char *argv[]) {
     size_t sample_idx = 0;
     density[sample_idx++] = (double)sum / (double)N;
 
-    fprintf(stderr, "Initial: density=%.6f, active=%zu, boundary=%zu, threshold=%.2f\n",
-            density[0], frontier.active_count, frontier.boundary_count, FRONTIER_DENSITY_THRESHOLD);
+    fprintf(stderr, "Initial: density=%.6f, active=%zu, boundary=%zu\n",
+            density[0], use_frontier ? frontier.active_count : 0u, use_frontier ? frontier.boundary_count : 0u);
 
-    /* Get activation function pointer once */
+    /* Prepare Gillespie simulation context */
     cp_activation_func_t activation_func = cp_get_activation_function(activation);
-    double invN = 1.0 / (double)N;
+    double *rates = __chMalloc(N * sizeof(*rates));
+    double total_rate = 0.0;
+    cp_rate_init(N, state, lambda, activation_func, rates, &total_rate);
 
-    cp_frontier_sim_t sim = {
+    cp_gillespie_sim_t sim = {
         .gamma = gamma,
         .N = N,
         .state = state,
         .lambda = lambda,
+        .rates = rates,
+        .total_rate = total_rate,
         .node_edges = node_edges,
         .neigh_len = neigh_len,
-        .frontier = &frontier,
+        .frontier = use_frontier ? &frontier : NULL,
         .activation_func = activation_func,
+        .use_frontier_selector = use_frontier,
     };
+    cp_gillespie_set_selector(&sim);
 
-    /* Simulation loop */
-    size_t t;
-    for (t = 0; t < steps; ++t) {
-        /* Check for absorbing state */
-        if (cp_reached_absorbing_state(sum, N, t, steps)) {
+    size_t max_events = steps * N;
+    double current_time = 0.0;
+
+    for (size_t event = 0; event < max_events; ++event) {
+        if (sim.total_rate <= 0.0 || cp_reached_absorbing_state(sum, N, event, max_events)) {
             break;
         }
 
-        /* Adaptive algorithm selection based on density */
-        double current_density = (double)sum * invN;
-        int use_frontier = (current_density < FRONTIER_DENSITY_THRESHOLD);
+        double delta_t = -log(RNG_dbl()) / sim.total_rate;
+        current_time += delta_t;
 
-        if (use_frontier) {
-            /* Low density: use frontier optimization */
-            cp_frontier_sweep_result_t frontier_result = cp_run_frontier_sweep(&sim, &sum);
-            if (frontier_result.frontier_size == 0) {
-                fprintf(stderr, "Reached absorbing state at t=%zu (empty frontier)\n", t);
-                break;
-            }
-        } else {
-            /* High density: use standard random sampling */
-            (void)cp_run_dense_frontier_sweep(&sim, &sum);
+        size_t node = 0;
+        int selected = cp_gillespie_pick_node(&sim, &node);
+        if (!selected) {
+            break;
         }
 
-        /* Save density */
-        if (sample_idx < num_log_samples) {
+        int8_t old_state = state[node];
+        int8_t new_state = (int8_t)(1 - old_state);
+        cp_gillespie_apply_flip(&sim, node, old_state, new_state, &sum);
+
+        if (sample_idx < num_log_samples && ((event + 1) % N == 0)) {
             density[sample_idx++] = (double)sum / (double)N;
         }
     }
 
-    /* Fill remaining samples with final density if ended early */
     double final_density = (double)sum / (double)N;
     while (sample_idx < num_log_samples) {
         density[sample_idx++] = final_density;
     }
 
-    fprintf(stderr, "Complete: t=%zu, density=%.6f, active=%zu, boundary=%zu\n",
-            t, final_density, frontier.active_count, frontier.boundary_count);
+    fprintf(stderr, "Complete: density=%.6f, active=%zu, boundary=%zu, time=%.6f\n",
+            final_density, frontier.active_count, frontier.boundary_count, current_time);
 
     /* Write outputs */
     fwrite(density, sizeof(double), num_log_samples, f_dens);
@@ -140,7 +144,9 @@ int main(int argc, char *argv[]) {
 
     /* Cleanup */
     free(density);
-    cp_frontier_free(&frontier);
+    if (use_frontier) {
+        cp_frontier_free(&frontier);
+    }
     free(lambda);
     free(edges);
     for (size_t i = 0; i < N; ++i) {
@@ -152,6 +158,7 @@ int main(int argc, char *argv[]) {
     free(node_edges);
     free(neigh_len);
     free(state);
+    free(rates);
 
     return EXIT_SUCCESS;
 }

--- a/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.c
+++ b/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.c
@@ -1,5 +1,6 @@
 #include "LRGSG_cp.h"
 #include "LRGSG_utils.h"
+#include "sfmtrng.h"
 
 #include <stdio.h>
 #include <math.h>
@@ -68,6 +69,237 @@ void cp_lambda_update_neighbors(double gamma, size_t node, int delta_state,
         size_t neighbor = edges_node.neighbors[j];
         lambda[neighbor] += delta * edges_node.weights[j];
     }
+}
+
+double cp_calculate_rate(int8_t state, double lambda, cp_activation_func_t activation_func) {
+    return state ? 1.0 : activation_func(lambda);
+}
+
+void cp_rate_init(size_t N, const spin_tp state, const double *lambda,
+                  cp_activation_func_t activation_func, double *rates, double *total_rate) {
+    double accum = 0.0;
+    for (size_t i = 0; i < N; ++i) {
+        rates[i] = cp_calculate_rate(state[i], lambda[i], activation_func);
+        accum += rates[i];
+    }
+    *total_rate = accum;
+}
+
+void cp_rate_update(size_t node, const spin_tp state, const double *lambda,
+                    cp_activation_func_t activation_func, double *rates, double *total_rate) {
+    double new_rate = cp_calculate_rate(state[node], lambda[node], activation_func);
+    double delta = new_rate - rates[node];
+    rates[node] = new_rate;
+    *total_rate += delta;
+}
+
+void cp_update_rates_neighbors(size_t node, const NodesEdges node_edges, const size_tp neigh_len,
+                               const spin_tp state, const double *lambda,
+                               cp_activation_func_t activation_func, double *rates,
+                               double *total_rate) {
+    size_t degree = neigh_len[node];
+    NodeEdges edges_node = node_edges[node];
+    for (size_t j = 0; j < degree; ++j) {
+        size_t neighbor = edges_node.neighbors[j];
+        cp_rate_update(neighbor, state, lambda, activation_func, rates, total_rate);
+    }
+}
+
+int cp_gillespie_select_event(size_t N, const double *rates, double total_rate, size_t *selected_node) {
+    if (total_rate <= 0.0) {
+        return 0;
+    }
+
+    double threshold = RNG_dbl() * total_rate;
+    double cumulative = 0.0;
+    for (size_t i = 0; i < N; ++i) {
+        cumulative += rates[i];
+        if (cumulative >= threshold) {
+            *selected_node = i;
+            return 1;
+        }
+    }
+
+    *selected_node = N - 1;
+    return 1;
+}
+
+int cp_gillespie_select_event_frontier(const cp_frontier_t *frontier, const double *rates,
+                                       double total_rate, size_t *selected_node) {
+    size_t frontier_size = frontier->active_count + frontier->boundary_count;
+    if (frontier_size == 0 || total_rate <= 0.0) {
+        return 0;
+    }
+
+    double threshold = RNG_dbl() * total_rate;
+    double cumulative = 0.0;
+
+    for (size_t idx = 0; idx < frontier->active_count; ++idx) {
+        size_t node = frontier->active_list[idx];
+        cumulative += rates[node];
+        if (cumulative >= threshold) {
+            *selected_node = node;
+            return 1;
+        }
+    }
+
+    for (size_t idx = 0; idx < frontier->boundary_count; ++idx) {
+        size_t node = frontier->boundary_list[idx];
+        cumulative += rates[node];
+        if (cumulative >= threshold) {
+            *selected_node = node;
+            return 1;
+        }
+    }
+
+    if (frontier->boundary_count > 0) {
+        *selected_node = frontier->boundary_list[frontier->boundary_count - 1];
+        return 1;
+    }
+    if (frontier->active_count > 0) {
+        *selected_node = frontier->active_list[frontier->active_count - 1];
+        return 1;
+    }
+
+    return 0;
+}
+
+static inline int cp_select_node_frontier(const cp_gillespie_sim_t *sim, size_t *node_out) {
+    return cp_gillespie_select_event_frontier(sim->frontier, sim->rates, sim->total_rate, node_out);
+}
+
+static inline int cp_select_node_dense(const cp_gillespie_sim_t *sim, size_t *node_out) {
+    return cp_gillespie_select_event(sim->N, sim->rates, sim->total_rate, node_out);
+}
+
+void cp_gillespie_set_selector(cp_gillespie_sim_t *sim) {
+    sim->select_node = sim->use_frontier_selector ? cp_select_node_frontier : cp_select_node_dense;
+}
+
+int cp_gillespie_pick_node(const cp_gillespie_sim_t *sim, size_t *node_out) {
+    if (sim->select_node) {
+        return sim->select_node(sim, node_out);
+    }
+    return sim->use_frontier_selector ? cp_select_node_frontier(sim, node_out)
+                                      : cp_select_node_dense(sim, node_out);
+}
+
+void cp_gillespie_apply_flip(cp_gillespie_sim_t *sim, size_t node, int8_t old_state, int8_t new_state,
+                             size_t *sum_ptr) {
+    int delta = (int)new_state - (int)old_state;
+    sim->state[node] = new_state;
+    if (delta > 0) {
+        ++(*sum_ptr);
+    } else {
+        --(*sum_ptr);
+    }
+
+    cp_lambda_update_neighbors(sim->gamma, node, delta, sim->node_edges, sim->neigh_len, sim->lambda);
+
+    if (sim->frontier) {
+        if (new_state) {
+            cp_frontier_node_activate(sim->frontier, node, sim->node_edges, sim->neigh_len, sim->state, sim->lambda);
+        } else {
+            cp_frontier_node_deactivate(sim->frontier, node, sim->node_edges, sim->neigh_len, sim->state, sim->lambda);
+        }
+    }
+
+    cp_rate_update(node, sim->state, sim->lambda, sim->activation_func, sim->rates, &sim->total_rate);
+    cp_update_rates_neighbors(node, sim->node_edges, sim->neigh_len, sim->state, sim->lambda, sim->activation_func,
+                              sim->rates, &sim->total_rate);
+}
+
+static inline int cp_single_update_cached(cp_cached_sim_t *sim, size_t *sum_ptr) {
+    size_t node = (size_t)(RNG_u64() % sim->N);
+    double prob = sim->activation_func(sim->lambda[node]);
+    int8_t old_state = sim->state[node];
+    int8_t new_state = (int8_t)(RNG_dbl() < prob);
+
+    if (new_state != old_state) {
+        int delta = (int)new_state - (int)old_state;
+        sim->state[node] = new_state;
+        if (delta > 0) {
+            ++(*sum_ptr);
+        } else {
+            --(*sum_ptr);
+        }
+        cp_lambda_update_neighbors(sim->gamma, node, delta, sim->node_edges, sim->neigh_len, sim->lambda);
+        return 1;
+    }
+    return 0;
+}
+
+size_t cp_run_sweep_cached(cp_cached_sim_t *sim, size_t *sum_ptr) {
+    size_t flips = 0;
+    for (size_t sweep = 0; sweep < sim->N; ++sweep) {
+        flips += (size_t)cp_single_update_cached(sim, sum_ptr);
+    }
+    return flips;
+}
+
+static inline void cp_apply_flip_with_frontier(cp_frontier_sim_t *sim, size_t node, int8_t old_state,
+                                               int8_t new_state, size_t *sum_ptr) {
+    int delta = (int)new_state - (int)old_state;
+    sim->state[node] = new_state;
+    if (delta > 0) {
+        ++(*sum_ptr);
+    } else {
+        --(*sum_ptr);
+    }
+
+    cp_lambda_update_neighbors(sim->gamma, node, delta, sim->node_edges, sim->neigh_len, sim->lambda);
+
+    if (new_state) {
+        cp_frontier_node_activate(sim->frontier, node, sim->node_edges, sim->neigh_len, sim->state, sim->lambda);
+    } else {
+        cp_frontier_node_deactivate(sim->frontier, node, sim->node_edges, sim->neigh_len, sim->state, sim->lambda);
+    }
+}
+
+cp_frontier_sweep_result_t cp_run_frontier_sweep(cp_frontier_sim_t *sim, size_t *sum_ptr) {
+    cp_frontier_sweep_result_t result = {.flips = 0, .frontier_size = sim->frontier->active_count + sim->frontier->boundary_count};
+    if (result.frontier_size == 0) {
+        return result;
+    }
+
+    for (size_t sweep = 0; sweep < sim->N; ++sweep) {
+        size_t pick = (size_t)(RNG_u64() % result.frontier_size);
+        size_t node = (pick < sim->frontier->active_count)
+                          ? sim->frontier->active_list[pick]
+                          : sim->frontier->boundary_list[pick - sim->frontier->active_count];
+
+        double prob = sim->activation_func(sim->lambda[node]);
+        int8_t old_state = sim->state[node];
+        int8_t new_state = (int8_t)(RNG_dbl() < prob);
+
+        if (new_state != old_state) {
+            cp_apply_flip_with_frontier(sim, node, old_state, new_state, sum_ptr);
+            ++result.flips;
+
+            result.frontier_size = sim->frontier->active_count + sim->frontier->boundary_count;
+            if (result.frontier_size == 0) {
+                break;
+            }
+        }
+    }
+
+    return result;
+}
+
+size_t cp_run_dense_frontier_sweep(cp_frontier_sim_t *sim, size_t *sum_ptr) {
+    size_t flips = 0;
+    for (size_t sweep = 0; sweep < sim->N; ++sweep) {
+        size_t node = (size_t)(RNG_u64() % sim->N);
+        double prob = sim->activation_func(sim->lambda[node]);
+        int8_t old_state = sim->state[node];
+        int8_t new_state = (int8_t)(RNG_dbl() < prob);
+
+        if (new_state != old_state) {
+            cp_apply_flip_with_frontier(sim, node, old_state, new_state, sum_ptr);
+            ++flips;
+        }
+    }
+    return flips;
 }
 
 /* Activation function: RELU - clipped to [0,1] */

--- a/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.h
+++ b/src/lrgsglib/Ccore/statsys/contactP/LRGSG_cp.h
@@ -8,6 +8,8 @@
 #define SOUT_FNAME CP_DIR "sout_" PSTR "_%s" BINX
 #define DENS_FNAME CP_DIR "dens_" PSTR "_%s" BINX
 
+typedef struct cp_frontier_t cp_frontier_t;
+
 /* Contact-process helper routines */
 double cp_infection_rate(size_t node, spin_tp state, size_t degree, NodeEdges edges);
 double cp_recovery_rate(size_t node, double mu, spin_tp state, size_t degree, NodeEdges edges);
@@ -29,6 +31,50 @@ void cp_lambda_init(double gamma, const spin_tp state, size_t N,
 void cp_lambda_update_neighbors(double gamma, size_t node, int delta_state,
                                 const NodesEdges node_edges, const size_tp neigh_len,
                                 double *lambda);
+double cp_calculate_rate(int8_t state, double lambda, cp_activation_func_t activation_func);
+void cp_rate_init(size_t N, const spin_tp state, const double *lambda,
+                  cp_activation_func_t activation_func, double *rates, double *total_rate);
+void cp_rate_update(size_t node, const spin_tp state, const double *lambda,
+                    cp_activation_func_t activation_func, double *rates, double *total_rate);
+void cp_update_rates_neighbors(size_t node, const NodesEdges node_edges, const size_tp neigh_len,
+                               const spin_tp state, const double *lambda,
+                               cp_activation_func_t activation_func, double *rates,
+                               double *total_rate);
+int cp_gillespie_select_event(size_t N, const double *rates, double total_rate, size_t *selected_node);
+int cp_gillespie_select_event_frontier(const cp_frontier_t *frontier, const double *rates,
+                                       double total_rate, size_t *selected_node);
+
+typedef struct {
+    double gamma;
+    size_t N;
+    spin_tp state;
+    double *lambda;
+    const NodesEdges node_edges;
+    const size_tp neigh_len;
+    cp_activation_func_t activation_func;
+} cp_cached_sim_t;
+
+size_t cp_run_sweep_cached(cp_cached_sim_t *sim, size_t *sum_ptr);
+
+typedef struct {
+    double gamma;
+    size_t N;
+    spin_tp state;
+    double *lambda;
+    double *rates;
+    double total_rate;
+    const NodesEdges node_edges;
+    const size_tp neigh_len;
+    cp_frontier_t *frontier;  // Optional frontier, used when selecting only active/boundary nodes
+    cp_activation_func_t activation_func;
+    int use_frontier_selector;
+    int (*select_node)(const struct cp_gillespie_sim_t *sim, size_t *node_out);
+} cp_gillespie_sim_t;
+
+int cp_gillespie_pick_node(const cp_gillespie_sim_t *sim, size_t *node_out);
+void cp_gillespie_set_selector(cp_gillespie_sim_t *sim);
+void cp_gillespie_apply_flip(cp_gillespie_sim_t *sim, size_t node, int8_t old_state, int8_t new_state,
+                             size_t *sum_ptr);
 
 /* Active border data structure for optimized contact process */
 typedef struct {
@@ -61,7 +107,7 @@ typedef enum {
     NODE_ACTIVE = 2     // In active list (state=1)
 } cp_node_status_t;
 
-typedef struct {
+typedef struct cp_frontier_t {
     size_t *active_list;            // List of active nodes (state=1)
     size_t *boundary_list;          // List of boundary nodes (state=0, has active neighbor)
     size_t *pos_active;             // Position lookup for active_list
@@ -85,5 +131,24 @@ void cp_frontier_node_activate(cp_frontier_t *frontier, size_t node,
 void cp_frontier_node_deactivate(cp_frontier_t *frontier, size_t node,
                                  const NodesEdges node_edges, const size_tp neigh_len,
                                  const spin_tp state, const double *lambda);
+
+typedef struct {
+    double gamma;
+    size_t N;
+    spin_tp state;
+    double *lambda;
+    const NodesEdges node_edges;
+    const size_tp neigh_len;
+    cp_frontier_t *frontier;
+    cp_activation_func_t activation_func;
+} cp_frontier_sim_t;
+
+typedef struct {
+    size_t flips;
+    size_t frontier_size;
+} cp_frontier_sweep_result_t;
+
+cp_frontier_sweep_result_t cp_run_frontier_sweep(cp_frontier_sim_t *sim, size_t *sum_ptr);
+size_t cp_run_dense_frontier_sweep(cp_frontier_sim_t *sim, size_t *sum_ptr);
 
 #endif /* __LRGSGCPLIB_H_INC__ */

--- a/src/lrgsglib/statsys/ContactProcess.py
+++ b/src/lrgsglib/statsys/ContactProcess.py
@@ -8,8 +8,9 @@ This module provides two flavours of contact-process dynamics:
   ``ContactSimulator0`` C kernel.
 * :class:`ContactProcessEI` implements excitation-inhibition dynamics driven
   by ``gamma`` and activation choice, mapping to the ``ContactSimulator1*``
-  kernels (``runlang`` values ``C1``, ``C1a``, ``C1b``, ``C1c``, ``C1d``). This path
-  encapsulates the degree rescaling expected by the C implementations.
+  kernels (``runlang`` values ``C1``, ``C1a``, ``C1b``, ``C1c``, ``C1d``,
+  ``C1e``). This path encapsulates the degree rescaling expected by the C
+  implementations.
 
 Examples
 --------
@@ -370,10 +371,14 @@ class ContactProcessEI(ContactProcessBase):
     This class is intended for the C backends (``runlang`` starting with
     ``C1``). Python dynamics are not provided for the excitation-inhibition
     path. The ``C1d`` variant uses adaptive frontier optimization for improved
-    performance when density is low (< 0.15).
+    performance when density is low (< 0.15). The ``C1e`` variant reuses the
+    cached-``lambda`` update scheme without maintaining a frontier and shares
+    the ``num_log_samples`` argument with ``C1c`` and ``C1d``. The ``C1f``
+    variant introduces a Gillespie-style event-driven loop over the frontier
+    for low-density regimes.
     """
 
-    _allowed_c_keys = ("C1", "C1A", "C1B", "C1C", "C1D")
+    _allowed_c_keys = ("C1", "C1A", "C1B", "C1C", "C1D", "C1E", "C1F")
 
     def __init__(
         self,
@@ -422,7 +427,7 @@ class ContactProcessEI(ContactProcessBase):
         if key == "C1A":
             nSampleLog = getattr(self, "nSampleLog", 100)
             args.append(f"{nSampleLog}")
-        elif key in ("C1C", "C1D"):
+        elif key in ("C1C", "C1D", "C1E", "C1F"):
             args.append(f"{self.num_log_samples}")
 
         return args

--- a/test/test_contact_process.py
+++ b/test/test_contact_process.py
@@ -130,6 +130,80 @@ class TestContactProcess(unittest.TestCase):
             model.remove_run_c_files(remove_stderr=True)
             model.sg.remove_exported_files()
 
+    def test_c1e_builder_arguments_include_cached_lambda_variant(self):
+        path_graph = nx.path_graph(4)
+        for u, v in path_graph.edges:
+            path_graph[u][v]["weight"] = 1.0
+        sg = self.SignedGraph(
+            path_graph,
+            pflip=0.0,
+            init_nw_dict=False,
+            path_data=self.data_dir,
+            path_plot=self.log_dir,
+        )
+        model = self.ContactProcessEI(
+            sg,
+            runlang="C1e",
+            gamma=0.5,
+            activation="tanh",
+            num_log_samples=15,
+            seed=0,
+            simpref=1,
+        )
+        model.simtime = 30
+        model.init_contact_dynamics()
+        try:
+            expected_binary = self.ccore_dir / "ContactSimulator1e"
+            self.assertEqual(Path(model.cprogram[0]), expected_binary)
+            self.assertEqual(model.cprogram[1], str(model.N))
+            self.assertEqual(model.cprogram[2], f"{model.sg.pflip:.12g}")
+            self.assertEqual(model.cprogram[3], f"{model.gamma_eff:.12g}")
+            self.assertEqual(model.cprogram[4], f"{model.simtime}")
+            self.assertEqual(model.cprogram[-2], model.activation)
+            self.assertEqual(model.cprogram[-1], f"{model.num_log_samples}")
+        finally:
+            if model.stderr_fopen and not model.stderr_fopen.closed:
+                model.stderr_fopen.close()
+            model.remove_run_c_files(remove_stderr=True)
+            model.sg.remove_exported_files()
+
+    def test_c1f_builder_arguments_include_gillespie_variant(self):
+        path_graph = nx.path_graph(3)
+        for u, v in path_graph.edges:
+            path_graph[u][v]["weight"] = 1.0
+        sg = self.SignedGraph(
+            path_graph,
+            pflip=0.0,
+            init_nw_dict=False,
+            path_data=self.data_dir,
+            path_plot=self.log_dir,
+        )
+        model = self.ContactProcessEI(
+            sg,
+            runlang="C1f",
+            gamma=0.75,
+            activation="relu",
+            num_log_samples=12,
+            seed=1,
+            simpref=1,
+        )
+        model.simtime = 25
+        model.init_contact_dynamics()
+        try:
+            expected_binary = self.ccore_dir / "ContactSimulator1f"
+            self.assertEqual(Path(model.cprogram[0]), expected_binary)
+            self.assertEqual(model.cprogram[1], str(model.N))
+            self.assertEqual(model.cprogram[2], f"{model.sg.pflip:.12g}")
+            self.assertEqual(model.cprogram[3], f"{model.gamma_eff:.12g}")
+            self.assertEqual(model.cprogram[4], f"{model.simtime}")
+            self.assertEqual(model.cprogram[-2], model.activation)
+            self.assertEqual(model.cprogram[-1], f"{model.num_log_samples}")
+        finally:
+            if model.stderr_fopen and not model.stderr_fopen.closed:
+                model.stderr_fopen.close()
+            model.remove_run_c_files(remove_stderr=True)
+            model.sg.remove_exported_files()
+
     def test_sir_step_recovery_and_infection(self):
         sg = self._make_graph()
         model = self.ContactProcessSIR(


### PR DESCRIPTION
## Summary
- add a cached selector callback to the Gillespie simulation context to avoid per-event branching
- expose a setter for the selector and initialize it in ContactSimulator1f before the main event loop
- keep the frontier-aware Gillespie path selectable while reducing dispatch overhead

## Testing
- python -m compileall src/lrgsglib/statsys/ContactProcess.py
- pytest test/test_contact_process.py -k c1f_builder_arguments_include_gillespie_variant

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9eee0020832daa1d2280b05d172a)